### PR TITLE
Added basic promote task generation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,7 +135,6 @@ DEPENDENCIES
   pry-rescue
   pry-stack_explorer
   pry-state
-  rake (~> 10.0)
   rb-fsevent
   rspec (~> 3.4)
   rubocop (~> 0.37)

--- a/README.md
+++ b/README.md
@@ -25,52 +25,52 @@
 KapostDeploy::Task creates the following rake tasks to aid in the promotion deployment of
 standard heroku applications (usually provisioned using https://github.com/kapost/heroku-cabbage)
 
-[promote]
-  Promotes a source environment to production
+    [promote]
+      Promotes a source environment to production
 
-[before_promote]
-  Executes application-defined before promotion code as defined in task config (See below)
+    [before_promote]
+      Executes application-defined before promotion code as defined in task config (See below)
 
-[after_promote]
-  Executes application-defined after promotion code as defined in task config (See below)
+    [after_promote]
+      Executes application-defined after promotion code as defined in task config (See below)
 
 Simple Example:
 
-  require 'kapost_deploy/task'
+    require 'kapost_deploy/task'
 
-  KapostDeploy::Task.new do |config|
-    config.app = 'cabbage-democ'
-    config.to = 'cabbage-prodc'
+    KapostDeploy::Task.new do |config|
+      config.app = 'cabbage-democ'
+      config.to = 'cabbage-prodc'
 
-    config.after do
-      puts "It's Miller time"
+      config.after do
+        puts "It's Miller time"
+      end
     end
-  end
 
 A slightly more complex example which will create 6 rake tasks: before_stage, stage,
 after_stage, before_promote, promote, after_promote
 
-  KapostDeploy::Task.new(:stage) do |config|
-    config.app = 'cabbage-stagingc'
-    config.to = %w[cabbage-sandboxc cabbage-democ]
+    KapostDeploy::Task.new(:stage) do |config|
+      config.app = 'cabbage-stagingc'
+      config.to = %w[cabbage-sandboxc cabbage-democ]
 
-    config.after do
-      sleep 60*2 wait for dynos to restart
-      slack.notify "The eagle has landed. [Go validate](https://testbed.sandbox.com/dashboard)!"
-      Launchy.open("https://testbed.sandbox.com/dashboard")
+      config.after do
+        sleep 60*2 wait for dynos to restart
+        slack.notify "The eagle has landed. [Go validate](https://testbed.sandbox.com/dashboard)!"
+        Launchy.open("https://testbed.sandbox.com/dashboard")
+      end
     end
-  end
 
-  KapostDeploy::Task.new(:promote) do |config|
-    config.app = 'cabbage-sandbox1c'
-    config.to = 'cabbage-prodc'
+    KapostDeploy::Task.new(:promote) do |config|
+      config.app = 'cabbage-sandbox1c'
+      config.to = 'cabbage-prodc'
 
-    config.before do
-      puts 'Are you sure you did x, y, and z? yes/no: '
-      confirm = gets.strip
-      exit(1) unless confirm.downcase == 'yes'
+      config.before do
+        puts 'Are you sure you did x, y, and z? yes/no: '
+        confirm = gets.strip
+        exit(1) unless confirm.downcase == 'yes'
+      end
     end
-  end
 
 # Requirements
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 # Features
 
-KapostDeploy::Task creates the following rake tasks to aid in the promotion deployment of
+`KapostDeploy::Task.define` creates the following rake tasks to aid in the promotion deployment of
 standard heroku applications (usually provisioned using https://github.com/kapost/heroku-cabbage)
 
     [promote]
@@ -38,7 +38,7 @@ Simple Example:
 
     require 'kapost_deploy/task'
 
-    KapostDeploy::Task.new do |config|
+    KapostDeploy::Task.define do |config|
       config.app = 'cabbage-democ'
       config.to = 'cabbage-prodc'
 
@@ -50,7 +50,7 @@ Simple Example:
 A slightly more complex example which will create 6 rake tasks: before_stage, stage,
 after_stage, before_promote, promote, after_promote
 
-    KapostDeploy::Task.new(:stage) do |config|
+    KapostDeploy::Task.define(:stage) do |config|
       config.app = 'cabbage-stagingc'
       config.to = %w[cabbage-sandboxc cabbage-democ]
 
@@ -61,7 +61,7 @@ after_stage, before_promote, promote, after_promote
       end
     end
 
-    KapostDeploy::Task.new(:promote) do |config|
+    KapostDeploy::Task.define(:promote) do |config|
       config.app = 'cabbage-sandbox1c'
       config.to = 'cabbage-prodc'
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
 require "gemsmith/rake/setup"
 Dir.glob("lib/tasks/*.rake").each { |file| load file }
 
-task default: %w(spec rubocop)
+task default: %w[spec rubocop]

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,7 @@
+dependencies:
+  pre:
+    - gem install bundler -v 1.11
+
+test:
+  override:
+    - bundle exec rake

--- a/kapost_deploy.gemspec
+++ b/kapost_deploy.gemspec
@@ -10,12 +10,11 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/kapost/kapost_deploy"
   spec.summary = "Deployment rake tasks for Kapost applications"
   spec.description = "Execute deployments swiftly and safely using `rake promote`"
-  spec.license = "Proprietary"
+  spec.license = "MIT"
 
   spec.add_dependency "rake", "~> 10.0"
 
   spec.add_development_dependency "bundler", "~> 1.11"
-  spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "gemsmith", "~> 7.6"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "pry-byebug"

--- a/lib/kapost_deploy.rb
+++ b/lib/kapost_deploy.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 require "kapost_deploy/identity"
+require "kapost_deploy/task"

--- a/lib/kapost_deploy/task.rb
+++ b/lib/kapost_deploy/task.rb
@@ -1,0 +1,145 @@
+require "rake"
+require "rake/tasklib"
+
+module KapostDeploy
+  ##
+  # KapostDeploy::Task creates the following rake tasks to aid in the promotion deployment of
+  # standard heroku applications (usually provisioned using
+  # https://github.com/kapost/heroku-cabbage)
+  #
+  # [promote]
+  #   Promotes a source envirnment to production
+  #
+  # [before_promote]
+  #   Executes application-defined before promotion code as defined in task config (See below)
+  #
+  # [after_promote]
+  #   Executes application-defined after promotion code as defined in task config (See below)
+  #
+  # Simple Example:
+  #
+  #   require 'kapost_deploy/task'
+  #
+  #   KapostDeploy::Task.new do |config|
+  #     config.app = 'cabbage-democ'
+  #     config.to = 'cabbage-prodc'
+  #
+  #     config.after do
+  #       puts "It's Miller time"
+  #     end
+  #   end
+  #
+  # A slightly more complex example which will create 6 rake tasks: before_stage, stage,
+  # after_stage, before_promote, promote, after_promote
+  #
+  #   KapostDeploy::Task.new(:stage) do |config|
+  #     config.app = 'cabbage-stagingc'
+  #     config.to = %w[cabbage-sandboxc cabbage-democ]
+  #
+  #     config.after do
+  #       sleep 60*2 # wait for dynos to restart
+  #       notifier.ping "The eagle has landed. [Go validate](https://testbed.sandbox.com/dashboard)!"
+  #       Launchy.open("https://testbed.sandbox.com/dashboard")
+  #     end
+  #   end
+  #
+  #   KapostDeploy::Task.new(:promote) do |config|
+  #     config.app = 'cabbage-sandbox1c'
+  #     config.to = 'cabbage-prodc'
+  #
+  #     config.before do
+  #       puts 'Are you sure you did x, y, and z? yes/no: '
+  #       confirm = gets.strip
+  #       exit(1) unless confirm.downcase == 'yes'
+  #     end
+  #   end
+  class Task < Rake::TaskLib
+    attr_accessor :app
+
+    attr_reader :to
+
+    attr_accessor :name
+
+    def initialize(name = :promote, shell: method(:sh)) # :yield: self
+      defaults
+      @name = name
+      @shell = shell
+
+      yield self if block_given?
+
+      validate
+
+      define
+    end
+
+    def before(&block)
+      @before = block
+    end
+
+    def after(&block)
+      @after = block
+    end
+
+    def to=(to)
+      @to = Array(to)
+    end
+
+    def defaults
+      @name = :promote
+      @app = nil
+      @to = []
+      @before = -> {}
+      @after = -> {}
+    end
+
+    def validate
+      fail "No 'app' configured. Set config.app to the application to be promoted" if app.nil?
+      fail "No 'to' configured. Set config.to to the downstream application(s) to be promoted to" if to.empty?
+    end
+
+    def define
+      define_dependencies
+      define_hooks
+
+      desc "Promote application to production environment"
+      task name.to_s => :install_pipelines do
+        @before.call
+        promote
+        @after.call
+      end
+    end
+
+    private
+
+    def shell(command)
+      @shell.call(command)
+    end
+
+    def define_dependencies
+      desc "Install heroku pipelines addon if necessary"
+      task :install_pipelines do
+        shell("heroku plugins:install heroku-pipelines") unless pipelines_installed?
+      end
+    end
+
+    def pipelines_installed?
+      `heroku plugins` =~ /^heroku-pipelines@/
+    end
+
+    def define_hooks
+      desc "Perform after-promotion tasks"
+      task :"after_#{name}" do
+        @after.call
+      end
+
+      desc "Perform before-promotion tasks"
+      task :"before_#{name}" do
+        @before.call
+      end
+    end
+
+    def promote
+      shell("heroku pipelines:promote -a #{app} --to #{to.join(",")}")
+    end
+  end
+end

--- a/lib/kapost_deploy/task.rb
+++ b/lib/kapost_deploy/task.rb
@@ -20,7 +20,7 @@ module KapostDeploy
   #
   #   require 'kapost_deploy/task'
   #
-  #   KapostDeploy::Task.new do |config|
+  #   KapostDeploy::Task.define do |config|
   #     config.app = 'cabbage-democ'
   #     config.to = 'cabbage-prodc'
   #
@@ -60,16 +60,13 @@ module KapostDeploy
 
     attr_accessor :name
 
-    def initialize(name = :promote, shell: method(:sh)) # :yield: self
-      defaults
-      @name = name
-      @shell = shell
+    def self.define(name = :promote, shell: method(:sh)) # :yield: self
+      instance = new(name, shell)
 
-      yield self if block_given?
+      yield instance if block_given?
 
-      validate
-
-      define
+      instance.validate
+      instance.define
     end
 
     def before(&block)
@@ -110,6 +107,12 @@ module KapostDeploy
     end
 
     private
+
+    def initialize(name, shell)
+      defaults
+      @name = name
+      @shell = shell
+    end
 
     def shell(command)
       @shell.call(command)

--- a/spec/lib/kapost_deploy/task_spec.rb
+++ b/spec/lib/kapost_deploy/task_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe KapostDeploy::Task do
   end
 
   subject! do
-    described_class.new(name, shell: ->(cmd) { command_spy.command(cmd) }) do |config|
+    described_class.define(name, shell: ->(cmd) { command_spy.command(cmd) }) do |config|
       config.app = "scaryskulls-democ"
       config.to = "scaryskulls-prodc"
 
@@ -68,9 +68,10 @@ RSpec.describe KapostDeploy::Task do
   end
 
   shared_examples_for "a promote command" do
+    let(:expected_command) { "heroku pipelines:promote -a scaryskulls-democ --to scaryskulls-prodc" }
     it "promotes to production" do
       Rake::Task[name].execute
-      expect(command_spy).to have_received(:command).with("heroku pipelines:promote -a scaryskulls-democ --to scaryskulls-prodc").once
+      expect(command_spy).to have_received(:command).with(expected_command).once
     end
   end
 

--- a/spec/lib/kapost_deploy/task_spec.rb
+++ b/spec/lib/kapost_deploy/task_spec.rb
@@ -1,0 +1,88 @@
+require "spec_helper"
+
+RSpec.describe KapostDeploy::Task do
+  after do
+    Rake.application = Rake::Application.new
+  end
+
+  subject! do
+    described_class.new(name, shell: ->(cmd) { command_spy.command(cmd) }) do |config|
+      config.app = "scaryskulls-democ"
+      config.to = "scaryskulls-prodc"
+
+      config.before do
+        hook_spy.before
+      end
+
+      config.after do
+        hook_spy.after
+      end
+    end
+  end
+
+  let(:name) { :promote }
+  let(:hook_spy) { double("hook spies", before: true, after: true) }
+  let(:command_spy) { double("command_spy", command: true) }
+
+  shared_examples_for "a task definer" do
+    it "creates named task" do
+      expect(Rake.application[name]).to be_a(Rake::Task)
+    end
+
+    it "creates 'before_<name>' task" do
+      expect(Rake.application["before_#{name}"]).to be_a(Rake::Task)
+    end
+
+    it "creates 'after_<name>' task" do
+      expect(Rake.application["after_#{name}"]).to be_a(Rake::Task)
+    end
+  end
+
+  shared_examples_for "a hook invoker" do
+    it "calls before hook" do
+      Rake::Task[name].execute
+      expect(hook_spy).to have_received(:before).once
+    end
+
+    it "calls after hook" do
+      Rake::Task[name].execute
+      expect(hook_spy).to have_received(:after).once
+    end
+
+    context "when before_<name> hook is invoked" do
+      it "calls only before hook" do
+        Rake::Task["before_#{name}"].execute
+        expect(hook_spy).to have_received(:before).once
+        expect(command_spy).to_not have_received(:command)
+      end
+    end
+
+    context "when after_<name> hook is invoked" do
+      it "calls only before hook" do
+        Rake::Task["after_#{name}"].execute
+        expect(hook_spy).to have_received(:after).once
+        expect(hook_spy).to_not have_received(:before)
+        expect(command_spy).to_not have_received(:command)
+      end
+    end
+  end
+
+  shared_examples_for "a promote command" do
+    it "promotes to production" do
+      Rake::Task[name].execute
+      expect(command_spy).to have_received(:command).with("heroku pipelines:promote -a scaryskulls-democ --to scaryskulls-prodc").once
+    end
+  end
+
+  it_behaves_like "a task definer"
+  it_behaves_like "a hook invoker"
+  it_behaves_like "a promote command"
+
+  context "customized name" do
+    let(:name) { :gobbledigook }
+
+    it_behaves_like "a task definer"
+    it_behaves_like "a hook invoker"
+    it_behaves_like "a promote command"
+  end
+end


### PR DESCRIPTION
Now you can promote an app and run custom before and after hooks

``` ruby
KapostDeploy::Task.define do |config|
  config.app = 'cabbage-democ'
  config.to = 'cabbage-prodc'

  config.after do
    puts "It's Miller time"
  end
end

$ rake promote
> heroku pipelines:promote -a cabbage-democ --to cabbage-prodc
> It's Miller time

```
