### PR TITLE
Added support for slack notifications

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     kapost_deploy (0.1.0)
       heroku (~> 3.43)
       rake (~> 10.0)
+      slack-notify (~> 0.4.1)
 
 GEM
   remote: https://rubygems.org/
@@ -20,6 +21,8 @@ GEM
     diff-lcs (1.2.5)
     docile (1.1.5)
     excon (0.49.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.10)
     formatador (0.2.5)
     guard (2.13.0)
@@ -59,6 +62,7 @@ GEM
     method_source (0.8.2)
     mime-types (1.25.1)
     multi_json (1.11.2)
+    multipart-post (2.0.0)
     nenv (0.3.0)
     net-ssh (2.9.2)
     net-ssh-gateway (1.2.0)
@@ -126,6 +130,9 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    slack-notify (0.4.1)
+      faraday (~> 0.9)
+      json (~> 1.8)
     slop (3.6.0)
     terminal-notifier (1.6.3)
     terminal-notifier-guard (1.7.0)

--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ stage:after_stage, promote:before_promote, promote, promote:after_promote
 # Requirements
 
 0. [MRI 2.3.0](https://www.ruby-lang.org)
+0. [Heroku Toolbelt](https://github.com/heroku/heroku) installed
+
+# Configuration Options
+
+* `app`: The application to be promoted
+* `to`: The downstream application(s) to receive the promotion. For multiple environments, use an array.
+* `slack_config`: An options hash containing the following keys:
+  * `webhook_url`: The webhook URL you added to your slack integrations
+  * `username`: The apparent username of the notifier *defaults to "webhooks bot"*
+  * `channel`: The channel name to post the notification to *defaults to "#general"*
+  * `icon_url`: A URL for the icon image *optional*
+  * `icon_emoji`: Emoji name to use instead of an icon *optional*
 
 # Setup
 

--- a/kapost_deploy.gemspec
+++ b/kapost_deploy.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rake", "~> 10.0"
   spec.add_dependency "heroku", "~> 3.43"
+  spec.add_dependency "slack-notify", "~> 0.4.1"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "pry"


### PR DESCRIPTION
![screenshot 2016-04-28 14 17 37](https://cloud.githubusercontent.com/assets/174332/14900037/fbfe72f2-0d4b-11e6-93f4-e262c3c69968.png)

@paul Here are the available slack_options:

```
{
  webhook_url: "http://", # required
  username: "deploy", # defaults to "webhooks bot"
  channel: "#deployments", # defaults to "#general"
  icon_url: "http://", # optional
  icon_emoji: "http://" # optional
}
```
