### PR TITLE
Created `NotifyHoneyBadgerAfterPromote` plugin.

### DIFF
--- a/kapost_deploy.gemspec
+++ b/kapost_deploy.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rake", ">= 10.0"
   spec.add_dependency "platform-api", ">= 0.6.0"
   spec.add_dependency "slack-notify", ">= 0.4.1"
+  spec.add_dependency "honeybadger", "~> 2.0"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "pry"

--- a/lib/kapost_deploy/plugins/notify_honeybadger_after_promote.rb
+++ b/lib/kapost_deploy/plugins/notify_honeybadger_after_promote.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "kapost_deploy/heroku/app_releases"
+
+module KapostDeploy
+  module Plugins
+    class NotifyHoneyBadgerAfterPromote
+      def initialize(config,
+                     ahead_releases: KapostDeploy::Heroku::AppReleases.new(config.app, token: config.heroku_api_token))
+        self.config = config
+        self.git_config = config.options.fetch(:git_config, nil)
+        self.ahead_releases = ahead_releases
+      end
+
+      def before
+      end
+
+      def after
+        notify_honeybadger
+      end
+
+      private
+
+      attr_accessor :config, :git_config, :ahead_releases
+
+      def notify_honeybadger
+        system("bundle exec honeybadger deploy -e #{env} -s #{commit_sha} -r #{repository_url}")
+      end
+
+      def env
+        config.to.split("-").last
+      end
+
+      def commit_sha
+        ENV["CIRCLE_BUILD_NUM"] || pipeline_sha
+      end
+
+      def pipeline_sha
+        ahead_releases.latest_deploy_version
+      end
+
+      def repository_url
+        "https://github.com/#{git_config[:github_repo]}"
+      end
+    end
+  end
+end

--- a/spec/lib/kapost_deploy/plugins/notify_honeybadger_after_promote_spec.rb
+++ b/spec/lib/kapost_deploy/plugins/notify_honeybadger_after_promote_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "kapost_deploy/plugins/notify_honeybadger_after_promote"
+
+RSpec.describe KapostDeploy::Plugins::NotifyHoneyBadgerAfterPromote do
+  let(:git_config) { { github_repo: "kapost/kapost_deploy", path: "." } }
+  let(:ahead_releases_double) { double("ahead releases", latest_deploy_version: "1234abc") }
+
+  subject { described_class.new(config, ahead_releases: ahead_releases_double) }
+
+  let(:config) do
+    KapostDeploy::Task.define(:test) do |config|
+      config.app = "scaryskulls-democ"
+      config.to = "scaryskulls-prodc"
+      config.pipeline = "scaryskulls"
+      config.heroku_api_token = "123"
+
+      config.options = { git_config: git_config }
+    end
+  end
+
+  it "notifies honeybadger after promote" do
+    expect(subject)
+      .to receive(:system)
+      .with("bundle exec honeybadger deploy -e prodc -s 1234abc -r https://github.com/kapost/kapost_deploy")
+
+    subject.after
+  end
+end


### PR DESCRIPTION
### Overview
- Pulled this in from what we were using in arugula.
- After a promote will end up calling something like:
  
  `bundle exec honeybadger deploy -e prodc -s 1234abc -r https://github.com/kapost/kapost_deploy`
  
  which will inform honeybadger.  As a honeybager.io site config option you can use it to clear all honey badgers upon receiving this deploy message.
