### PR TITLE
Created `NotifyHoneyBadgerAfterPromote` plugin.

### DIFF
--- a/kapost_deploy.gemspec
+++ b/kapost_deploy.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rake", ">= 10.0"
   spec.add_dependency "platform-api", ">= 0.6.0"
   spec.add_dependency "slack-notify", ">= 0.4.1"
+  spec.add_dependency "honeybadger", "~> 2.0"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "pry"
@@ -32,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop", "~> 0.37"
   spec.add_development_dependency "codeclimate-test-reporter"
   spec.add_development_dependency "rubygems-tasks"
+  spec.add_development_dependency "climate_control"
 
   spec.files = Dir["lib/**/*", "vendor/**/*"]
   spec.extra_rdoc_files = Dir["README*", "LICENSE*"]

--- a/lib/kapost_deploy/identity.rb
+++ b/lib/kapost_deploy/identity.rb
@@ -11,7 +11,7 @@ module KapostDeploy
     end
 
     def self.version
-      "0.2.0"
+      "0.3.0"
     end
 
     def self.version_label

--- a/lib/kapost_deploy/plugins/notify_honeybadger_after_promote.rb
+++ b/lib/kapost_deploy/plugins/notify_honeybadger_after_promote.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "kapost_deploy/heroku/app_releases"
+
+module KapostDeploy
+  module Plugins
+    # After-promotion plugin to notify honeybadger after a promotion is complete.
+    # Honeybadger.io can be configured to clear all honeybadgers upon this deploy notification.
+    class NotifyHoneyBadgerAfterPromote
+      def initialize(config,
+                     ahead_releases: KapostDeploy::Heroku::AppReleases.new(config.app, token: config.heroku_api_token),
+                     kernel: Kernel)
+
+        self.config = config
+        self.git_config = config.options.fetch(:git_config, {})
+        self.ahead_releases = ahead_releases
+        self.kernel = kernel
+      end
+
+      def after
+        return unless configured?
+
+        notify_honeybadger
+      end
+
+      private
+
+      attr_accessor :config, :git_config, :ahead_releases, :kernel
+
+      def notify_honeybadger
+        kernel.system("bundle exec honeybadger deploy -e #{env} -s #{commit_sha} -r #{repository_url}")
+      end
+
+      def env
+        config.to.split("-").last
+      end
+
+      def commit_sha
+        ci_sha || pipeline_sha
+      end
+
+      def ci_sha
+        ENV["CIRCLE_SHA1"]
+      end
+
+      def pipeline_sha
+        ahead_releases.latest_deploy_version
+      end
+
+      def github_repo
+        git_config[:github_repo] unless git_config.nil?
+      end
+
+      def repository_url
+        "https://github.com/#{github_repo}"
+      end
+
+      def configured?
+        !github_repo.nil? && !github_repo.empty?
+      end
+    end
+  end
+end

--- a/spec/lib/kapost_deploy/plugins/notify_honeybadger_after_promote_spec.rb
+++ b/spec/lib/kapost_deploy/plugins/notify_honeybadger_after_promote_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "climate_control"
+require "kapost_deploy/plugins/notify_honeybadger_after_promote"
+
+RSpec.describe KapostDeploy::Plugins::NotifyHoneyBadgerAfterPromote do
+  let(:git_config) { { github_repo: "kapost/kapost_deploy", path: "." } }
+  let(:ahead_releases_double) { double("ahead releases", latest_deploy_version: "1234abc") }
+  let(:kernel) { class_spy(Kernel) }
+
+  subject { described_class.new(config, ahead_releases: ahead_releases_double, kernel: kernel) }
+
+  let(:config) do
+    KapostDeploy::Task.define(:test) do |config|
+      config.app = "scaryskulls-democ"
+      config.to = "scaryskulls-prodc"
+      config.pipeline = "scaryskulls"
+      config.heroku_api_token = "123"
+
+      config.options = { git_config: git_config }
+    end
+  end
+
+  context "when CIRCLE_SHA1 enviroment is not available" do
+    it "notifies honeybadger after promote using pipeline sha" do
+      ClimateControl.modify CIRCLE_SHA1: nil do
+        subject.after
+        expect(kernel)
+          .to have_received(:system)
+          .with("bundle exec honeybadger deploy -e prodc -s 1234abc -r https://github.com/kapost/kapost_deploy")
+      end
+    end
+  end
+
+  context "when CIRCLE_SHA1 enviroment is available" do
+    it "notifies honeybadger after promote using circle sha" do
+      ClimateControl.modify CIRCLE_SHA1: "19" do
+        subject.after
+        expect(kernel)
+          .to have_received(:system)
+          .with("bundle exec honeybadger deploy -e prodc -s 19 -r https://github.com/kapost/kapost_deploy")
+        subject.after
+      end
+    end
+  end
+
+  context "when git is not configured" do
+    let(:git_config) { nil }
+
+    it "does not notify" do
+      subject.after
+      expect(kernel).to_not have_received(:system)
+    end
+  end
+end


### PR DESCRIPTION
### Overview
- Pulled this in from what we were using in arugula.
- After a promote will end up calling something like:
  
  `bundle exec honeybadger deploy -e prodc -s 1234abc -r https://github.com/kapost/kapost_deploy`
  
  which will inform honeybadger.  As a honeybager.io site config option you can use it to clear all honey badgers upon receiving this deploy message.
