### PR TITLE
Don't require the heroku api token when defining the task

### DIFF
--- a/lib/kapost_deploy/plugins/validate_before_promote.rb
+++ b/lib/kapost_deploy/plugins/validate_before_promote.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module KapostDeploy
+  module Plugins
+    # Validates runtime configuration
+    class ValidateBeforePromote
+      def initialize(config)
+        @config = config
+      end
+
+      def before
+        fail <<~MSG unless @config.heroku_api_token
+          No 'heroku_api_token' configured. Set config.heroku_api_token to your
+          API secret token (use `heroku auth:token` to get it).
+        MSG
+      end
+    end
+  end
+end

--- a/lib/kapost_deploy/task.rb
+++ b/lib/kapost_deploy/task.rb
@@ -3,6 +3,7 @@
 require "rake"
 require "rake/tasklib"
 require "kapost_deploy/heroku/app_promoter"
+require "kapost_deploy/plugins/validate_before_promote"
 
 module KapostDeploy
   ##
@@ -41,6 +42,7 @@ module KapostDeploy
 
       instance.validate
       instance.define
+      instance.add_plugin(KapostDeploy::Plugins::ValidateBeforePromote)
       instance
     end
 
@@ -59,7 +61,7 @@ module KapostDeploy
     def defaults
       @name = :promote
       @pipeline = nil
-      @heroku_api_token = nil
+      @heroku_api_token = ENV["HEROKU_DEPLOY_API_TOKEN"]
       @app = nil
       @to = nil
       @before = -> {}
@@ -69,8 +71,6 @@ module KapostDeploy
     end
 
     def validate
-      fail "No 'heroku_api_token' configured."\
-           "Set config.heroku_api_token to your API secret token" if heroku_api_token.nil?
       fail "No 'pipeline' configured. Set config.pipeline to the name of your pipeline" if pipeline.nil?
       fail "No 'app' configured. Set config.app to the application to be promoted" if app.nil?
       fail "No 'to' configured. Set config.to to the downstream application to be promoted to" if to.nil?


### PR DESCRIPTION
This allows usage of other rake tasks (or even just listing them), without requiring heroku_api_token to be set.
