### PR TITLE
Added namespace support.

### DIFF
--- a/lib/kapost_deploy/identity.rb
+++ b/lib/kapost_deploy/identity.rb
@@ -12,7 +12,7 @@ module KapostDeploy
     end
 
     def self.version
-      "0.4.0"
+      "0.5.0"
     end
 
     def self.version_label

--- a/lib/kapost_deploy/task.rb
+++ b/lib/kapost_deploy/task.rb
@@ -87,21 +87,28 @@ module KapostDeploy
 
     private
 
-    def initialize(name)
+    def initialize(name, scope: Rake.application.current_scope.path)
       defaults
-      self.name = name
+      @name = name
+      @scope = scope
     end
 
     attr_accessor :plugins
+    attr_reader :scope
+
+    def hook_name(type)
+      return "#{name}:#{type}_#{name}" if scope.empty?
+      "#{scope}:#{name}:#{type}_#{name}"
+    end
 
     def promoter
       @promoter ||= KapostDeploy::Heroku::AppPromoter.new(pipeline, token: heroku_api_token)
     end
 
     def promote_with_hooks
-      Rake.application[:"#{name}:before_#{name}"].execute
+      Rake.application[hook_name("before")].execute
       promoter.promote(from: app, to: to)
-      Rake.application[:"#{name}:after_#{name}"].execute
+      Rake.application[hook_name("after")].execute
     end
 
     def shell(command)

--- a/spec/integrations/kapost_deploy_spec.rb
+++ b/spec/integrations/kapost_deploy_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rake"
+
+RSpec.describe KapostDeploy, :integration do
+  include ::Rake::DSL
+
+  let(:task_names) { Rake.application.tasks.map { |task| task.name.to_s } }
+  let :deploy_task do
+    KapostDeploy::Task.define(:stage) do |config|
+      config.app = "test-review"
+      config.to = "test-stage"
+      config.pipeline = "tester"
+    end
+  end
+
+  before { Rake::Task.clear }
+
+  context "without namespace" do
+    before { deploy_task }
+
+    it "answers namespaces deploy tasks" do
+      expect(task_names).to contain_exactly(
+        "stage",
+        "stage:before_stage",
+        "stage:after_stage"
+      )
+    end
+  end
+
+  context "with namespace" do
+    before do
+      namespace :deploy do
+        deploy_task
+      end
+    end
+
+    it "answers namespaces deploy tasks" do
+      expect(task_names).to contain_exactly(
+        "deploy:stage",
+        "deploy:stage:before_stage",
+        "deploy:stage:after_stage"
+      )
+    end
+  end
+end

--- a/spec/lib/kapost_deploy/task_spec.rb
+++ b/spec/lib/kapost_deploy/task_spec.rb
@@ -3,14 +3,6 @@
 require "spec_helper"
 
 RSpec.describe KapostDeploy::Task do
-  after do
-    Rake.application = Rake::Application.new
-  end
-
-  before do
-    allow(subject).to receive(:promoter).and_return(promoter_double)
-  end
-
   subject do
     described_class.define(name) do |config|
       config.app = "scaryskulls-democ"
@@ -34,6 +26,11 @@ RSpec.describe KapostDeploy::Task do
   let(:hook_spy) { double("hook spies", before: true, after: true) }
   let(:promoter_double) { double("promoter", promote: true) }
   let(:plugins) { [] }
+
+  before do
+    Rake::Task.clear
+    allow(subject).to receive(:promoter).and_return(promoter_double)
+  end
 
   shared_examples_for "a task definer" do
     it "creates named task" do


### PR DESCRIPTION
## Overview

Ran into a deployment issue when attempting to add Rake namespaces (for organizational purposes) to our apps. This will prevent deployment failures because the hooks were not properly defined within the namespace.
## Details
- See commits for details.
