### PR TITLE
Bumped version to 0.6.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
-# v0.6.0
+# Changelog
+
+## v0.6.1
+
+- Republishing v0.6.0 due to publishing issues.
+
+## v0.6.0 [yanked]
 
 - Upgraded vulnerable rubocop version.
 - Added `KapostDeploy::Plugins::NotifyDatadogAfterPromote`, for reporting promotions to datadog.
 
-# v0.1.0 (2016-04-27)
+## v0.1.0 (2016-04-27)
 
 - Initial version.

--- a/lib/kapost_deploy/identity.rb
+++ b/lib/kapost_deploy/identity.rb
@@ -12,7 +12,7 @@ module KapostDeploy
     end
 
     def self.version
-      "0.6.0"
+      "0.6.1"
     end
 
     def self.version_label


### PR DESCRIPTION
## Overview
Something happened with the last attempt to publish, and the 0.6.0 version was not correct.  I've yanked that and am bumping the version to try again.

After merging this, I plan to run `bundle exec publish`.