### PR TITLE
Require seismograph notifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.2
+
+- Added missing require line for `KapostDeploy::Plugins::NotifyDatadogAfterPromote` to work.
+
 ## v0.6.1
 
 - Republishing v0.6.0 due to publishing issues.

--- a/lib/kapost_deploy/identity.rb
+++ b/lib/kapost_deploy/identity.rb
@@ -12,7 +12,7 @@ module KapostDeploy
     end
 
     def self.version
-      "0.6.1"
+      "0.6.2"
     end
 
     def self.version_label

--- a/lib/kapost_deploy/plugins/notify_datadog_after_promote.rb
+++ b/lib/kapost_deploy/plugins/notify_datadog_after_promote.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "kapost_deploy/heroku/app_releases"
+require "kapost_deploy/seismograph/notifier"
 
 module KapostDeploy
   module Plugins

--- a/spec/lib/kapost_deploy/plugins/notify_datadog_after_promote_spec.rb
+++ b/spec/lib/kapost_deploy/plugins/notify_datadog_after_promote_spec.rb
@@ -4,7 +4,6 @@ require "spec_helper"
 require "climate_control"
 require "seismograph"
 require "kapost_deploy/plugins/notify_datadog_after_promote"
-require "kapost_deploy/seismograph/notifier"
 
 RSpec.describe KapostDeploy::Plugins::NotifyDatadogAfterPromote do
   let(:git_config) { { github_repo: "kapost/kapost_deploy", path: "." } }


### PR DESCRIPTION
## Overview
This adds a missing `require` line to the `NotifyDatadogAfterPromote` plugin.  Without it, we get an error when trying to deploy [as seen here](https://circleci.com/gh/kapost/napa/40746):

>     NameError: uninitialized constant KapostDeploy::Seismograph

## Details
* Adds missing `require`.
* Bumps version to 0.6.2.