### PR TITLE
circle2 + new cc reporter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,20 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/kapost_deploy
+    docker:
+      - image: kapost/ruby:2.4.2-node-6.11.5
+    steps:
+      - checkout
+      - run: bundle install
+      - run:
+          name: install cc-test-reporter
+          command: |
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+            chmod +x ./cc-test-reporter
+            ./cc-test-reporter before-build
+      - run:
+          name: Run tests
+          command: |
+            bundle exec rake
+            ./cc-test-reporter after-build --exit-code $?

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,0 @@
-dependencies:
-  pre:
-    - gem install bundler -v 1.11
-
-test:
-  override:
-    - bundle exec rake

--- a/kapost_deploy.gemspec
+++ b/kapost_deploy.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "climate_control"
-  spec.add_development_dependency "codeclimate-test-reporter"
   spec.add_development_dependency "gemsmith", "~> 10.0"
   spec.add_development_dependency "guard-rspec"
   spec.add_development_dependency "pry"
@@ -30,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "rubocop", "~> 0.52"
   spec.add_development_dependency "seismograph"
+  spec.add_development_dependency "simplecov"
   spec.add_development_dependency "terminal-notifier"
   spec.add_development_dependency "terminal-notifier-guard"
 


### PR DESCRIPTION
## Overview
CircleCI is sunsetting 1.0 configs and builds effective August 31, 2018. This gets kapost_deploy on a Circle 2.0 config.

I also re-added Code Climate coverage with the new test reporter.
