### PR TITLE
Open up honeybadger dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Opened up honeybadger dependency version from only 2.X to anything >= 2.0.
+
 ## v0.6.2
 
 - Added missing require line for `KapostDeploy::Plugins::NotifyDatadogAfterPromote` to work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,55 @@
 # Changelog
 
-## Unreleased
+## [Unreleased]
+
+## [v0.7.0] - 2018-11-30
 
 - Opened up honeybadger dependency version from only 2.X to anything >= 2.0.
 
-## v0.6.2
+## [v0.6.2] - 2018-03-06
 
 - Added missing require line for `KapostDeploy::Plugins::NotifyDatadogAfterPromote` to work.
 
-## v0.6.1
+## [v0.6.1] 2018-02-28
 
 - Republishing v0.6.0 due to publishing issues.
 
-## v0.6.0 [yanked]
+## [v0.6.0] **yanked** - 2016-11-21 
 
 - Upgraded vulnerable rubocop version.
 - Added `KapostDeploy::Plugins::NotifyDatadogAfterPromote`, for reporting promotions to datadog.
 
-## v0.1.0 (2016-04-27)
+## [v0.5.0] - 2016-08-03
+
+- Unknown
+
+## [v0.4.0] 2016-06-09
+
+- Unknown
+
+## [v0.3.0] - 2016-05-24
+
+- Unknown
+
+## [v0.2.0] - 2016-05-02
+
+- Unknown
+
+## [v0.1.1] - 2016-04-29
+
+- Unknown
+
+## v0.1.0 - 2016-04-27
 
 - Initial version.
+
+[Unreleased]: https://github.com/kapost/kapost_deploy/compare/v0.7.0...HEAD
+[v0.7.0]: https://github.com/kapost/kapost_deploy/compare/v0.6.2...v0.7.0
+[v0.6.2]: https://github.com/kapost/kapost_deploy/compare/v0.6.1...v0.6.2
+[v0.6.1]: https://github.com/kapost/kapost_deploy/compare/v0.6.0...v0.6.1
+[v0.6.0]: https://github.com/kapost/kapost_deploy/compare/v0.5.0...v0.6.0
+[v0.5.0]: https://github.com/kapost/kapost_deploy/compare/v0.4.0...v0.5.0
+[v0.4.0]: https://github.com/kapost/kapost_deploy/compare/v0.3.0...v0.4.0
+[v0.3.0]: https://github.com/kapost/kapost_deploy/compare/v0.2.0...v0.3.0
+[v0.2.0]: https://github.com/kapost/kapost_deploy/compare/v0.1.1...v0.2.0
+[v0.1.1]: https://github.com/kapost/kapost_deploy/compare/v0.1.0...v0.1.1

--- a/kapost_deploy.gemspec
+++ b/kapost_deploy.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.description = "Execute deployments swiftly and safely using `rake promote`"
   spec.license = "MIT"
 
-  spec.add_dependency "honeybadger", "~> 2.0"
+  spec.add_dependency "honeybadger", ">= 2.0"
   spec.add_dependency "platform-api", ">= 0.6.0"
   spec.add_dependency "rake", ">= 10.0"
   spec.add_dependency "slack-notify", ">= 0.4.1"

--- a/lib/kapost_deploy/identity.rb
+++ b/lib/kapost_deploy/identity.rb
@@ -12,7 +12,7 @@ module KapostDeploy
     end
 
     def self.version
-      "0.6.2"
+      "0.7.0"
     end
 
     def self.version_label


### PR DESCRIPTION
## Overview
The `honeybadger` version was too restrictive.  Opening it up, as there is nothing we are doing that won't work with newer versions.

Also cleaned up the CHANGELOG while I was in there.